### PR TITLE
Fix bug where newlines are ignored

### DIFF
--- a/src/Prometheus.Client.Owin/PrometheusExtensions.cs
+++ b/src/Prometheus.Client.Owin/PrometheusExtensions.cs
@@ -42,7 +42,7 @@ namespace Prometheus.Client.Owin
                 coreapp.Run(async context =>
                 {
                     var response = context.Response;
-                    response.ContentType = "text/plain";
+                    response.ContentType = "text/plain; version=0.0.4";
                     
                     using (var outputStream = response.Body)
                     {

--- a/src/Prometheus.Client.Owin/PrometheusExtensions.cs
+++ b/src/Prometheus.Client.Owin/PrometheusExtensions.cs
@@ -42,6 +42,7 @@ namespace Prometheus.Client.Owin
                 coreapp.Run(async context =>
                 {
                     var response = context.Response;
+                    response.ContentType = "text/plain";
                     
                     using (var outputStream = response.Body)
                     {


### PR DESCRIPTION
the default content type being `text/html` strips out the newline characters, changing to `text/plain` fixes this.